### PR TITLE
[PREV-NEXT] Prev-next article only for those with same primary tag

### DIFF
--- a/custom-post-image.hbs
+++ b/custom-post-image.hbs
@@ -36,16 +36,12 @@
 
         <hr>
         <div class="prev-next">
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
-                {{#foreach posts}}
+            {{#next_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-                {{/foreach}}
-            {{/get}}
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
-                {{#foreach posts}}
+            {{/next_post}}
+            {{#prev_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-                {{/foreach}}
-            {{/get}}
+            {{/prev_post}}
         </div>
         <hr>
     </footer>

--- a/custom-post-image.hbs
+++ b/custom-post-image.hbs
@@ -36,12 +36,22 @@
 
         <hr>
         <div class="prev-next">
-            {{#next_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-            {{/next_post}}
-            {{#prev_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-            {{/prev_post}}
+            {{#has tag="#series"}}
+                {{#next_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{else}}
+                {{#next_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{/has}}
+
         </div>
         <hr>
     </footer>

--- a/custom-post-image.hbs
+++ b/custom-post-image.hbs
@@ -36,13 +36,16 @@
 
         <hr>
         <div class="prev-next">
-            {{#prev_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Previous article") class="u-marginBottom30"}}
-            {{/prev_post}}
-
-            {{#next_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Next article") class=""}}
-            {{/next_post}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/foreach}}
+            {{/get}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/foreach}}
+            {{/get}}
         </div>
         <hr>
     </footer>

--- a/custom-post-not-image.hbs
+++ b/custom-post-not-image.hbs
@@ -21,16 +21,12 @@
 
         <hr>
         <div class="prev-next">
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
-                {{#foreach posts}}
+            {{#next_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-                {{/foreach}}
-            {{/get}}
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
-                {{#foreach posts}}
+            {{/next_post}}
+            {{#prev_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-                {{/foreach}}
-            {{/get}}
+            {{/prev_post}}
         </div>
         <hr>
     </footer>

--- a/custom-post-not-image.hbs
+++ b/custom-post-not-image.hbs
@@ -21,12 +21,22 @@
 
         <hr>
         <div class="prev-next">
-            {{#next_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-            {{/next_post}}
-            {{#prev_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-            {{/prev_post}}
+            {{#has tag="#series"}}
+                {{#next_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{else}}
+                {{#next_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{/has}}
+
         </div>
         <hr>
     </footer>

--- a/custom-post-not-image.hbs
+++ b/custom-post-not-image.hbs
@@ -21,13 +21,16 @@
 
         <hr>
         <div class="prev-next">
-            {{#prev_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Previous article") class="u-marginBottom30"}}
-            {{/prev_post}}
-
-            {{#next_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Next article") class=""}}
-            {{/next_post}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/foreach}}
+            {{/get}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/foreach}}
+            {{/get}}
         </div>
         <hr>
     </footer>

--- a/custom-post-video.hbs
+++ b/custom-post-video.hbs
@@ -24,16 +24,12 @@
 
         <hr>
         <div class="prev-next">
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
-                {{#foreach posts}}
+            {{#next_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-                {{/foreach}}
-            {{/get}}
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
-                {{#foreach posts}}
+            {{/next_post}}
+            {{#prev_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-                {{/foreach}}
-            {{/get}}
+            {{/prev_post}}
         </div>
         <hr>
     </footer>

--- a/custom-post-video.hbs
+++ b/custom-post-video.hbs
@@ -24,13 +24,16 @@
 
         <hr>
         <div class="prev-next">
-            {{#prev_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Previous article") class="u-marginBottom30"}}
-            {{/prev_post}}
-
-            {{#next_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Next article") class=""}}
-            {{/next_post}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/foreach}}
+            {{/get}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/foreach}}
+            {{/get}}
         </div>
         <hr>
     </footer>

--- a/custom-post-video.hbs
+++ b/custom-post-video.hbs
@@ -24,12 +24,22 @@
 
         <hr>
         <div class="prev-next">
-            {{#next_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-            {{/next_post}}
-            {{#prev_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-            {{/prev_post}}
+            {{#has tag="#series"}}
+                {{#next_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{else}}
+                {{#next_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{/has}}
+
         </div>
         <hr>
     </footer>

--- a/post.hbs
+++ b/post.hbs
@@ -35,13 +35,16 @@
 
         <hr>
         <div class="prev-next">
-            {{#prev_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Previous article") class="u-marginBottom30"}}
-            {{/prev_post}}
-
-            {{#next_post}}
-                {{> "story/story-previous-next" storyTitle=(t "Next article") class=""}}
-            {{/next_post}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/foreach}}
+            {{/get}}
+            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
+                {{#foreach posts}}
+                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/foreach}}
+            {{/get}}
         </div>
         <hr>
     </footer>

--- a/post.hbs
+++ b/post.hbs
@@ -35,12 +35,22 @@
 
         <hr>
         <div class="prev-next">
-            {{#next_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-            {{/next_post}}
-            {{#prev_post in="primary_tag"}}
-                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-            {{/prev_post}}
+            {{#has tag="#series"}}
+                {{#next_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post in="primary_tag"}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{else}}
+                {{#next_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
+                {{/next_post}}
+                {{#prev_post}}
+                        {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
+                {{/prev_post}}
+            {{/has}}
+
         </div>
         <hr>
     </footer>

--- a/post.hbs
+++ b/post.hbs
@@ -35,16 +35,12 @@
 
         <hr>
         <div class="prev-next">
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
-                {{#foreach posts}}
+            {{#next_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
-                {{/foreach}}
-            {{/get}}
-            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
-                {{#foreach posts}}
+            {{/next_post}}
+            {{#prev_post in="primary_tag"}}
                     {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
-                {{/foreach}}
-            {{/get}}
+            {{/prev_post}}
         </div>
         <hr>
     </footer>


### PR DESCRIPTION
Hello, 

I've implemented this on my blog. 
The prev and next article only give you the articles with the same tags.
Here is the code that I added on all the post templates

```Hbs
<div class="prev-next">
            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:>{{id}}" limit="1"order="id asc"}}
                {{#foreach posts}}
                    {{> "story/story-previous-next" storyTitle=(t "Next article") class="u-marginBottom30"}}
                {{/foreach}}
            {{/get}}
            {{#get "posts" filter="tags:{{primary_tag.slug}}+id:<{{id}}" limit="1" order="id desc"}}
                {{#foreach posts}}
                    {{> "story/story-previous-next" storyTitle=(t "Previous article") class=""}}
                {{/foreach}}
            {{/get}}
        </div>
```