### PR TITLE
Add padding to container for home

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -2852,7 +2852,8 @@ body.is-transparent:not(.has-menu) .u-menu-color a {
   -webkit-box-align: stretch;
   align-items: stretch;
   width: 100%;
-  max-width: 1232px
+  max-width: 1232px;
+  padding: 50px;
 }
 
 .homeHero-container .hh-author {


### PR DESCRIPTION
As referenced in issue #71, there is no padding on the `.homeHero-container` for `medium-home.hbs`. This is added in this pull.