### PR TITLE
Fix amp url to include slash

### DIFF
--- a/partials/amp/amp-related.hbs
+++ b/partials/amp/amp-related.hbs
@@ -6,7 +6,7 @@
 
         {{#foreach related_posts}}
         <div class="story">
-            <a href="{{url absolute="true"}}amp" class="story-link relative flex items-center mb-3">
+            <a href="{{url absolute="true"}}amp/" class="story-link relative flex items-center mb-3">
                 <span class="story-link-icon felx items-center flex-none mr-3">{{@number}}</span>
                 <span class="story-link-text leading-snug">{{title}}</span>
             </a>


### PR DESCRIPTION
Currently related posts in AMP page are linked to /amp, which all the time result in additional redirect to /amp/ page. Adding /amp/ to avoid this extra 301 redirect.