### PR TITLE
archive-contact: correct font size of title

### DIFF
--- a/custom-archive-contact.hbs
+++ b/custom-archive-contact.hbs
@@ -8,7 +8,7 @@
 <article class="post-body godo-canvas mx-auto py-vmin8">
     <header class="text-center">
         <h1 class="mb-8 text-gray-600">{{title}}</h1>
-        {{#if custom_excerpt}}<p class="text-3xl text-title font-semibold">{{custom_excerpt}}</p>{{/if}}
+        {{#if custom_excerpt}}<p class="md:text-2xl text-gray-500 text-xl">{{custom_excerpt}}</p>{{/if}}
     </header>
 
     {{!-- Content --}}

--- a/custom-archive-contact.hbs
+++ b/custom-archive-contact.hbs
@@ -7,7 +7,7 @@
 {{#post}}
 <article class="post-body godo-canvas mx-auto py-vmin8">
     <header class="text-center">
-        <h1 class=" font-normal mb-8 text-xl text-gray-600">{{title}}</h1>
+        <h1 class="mb-8 text-gray-600">{{title}}</h1>
         {{#if custom_excerpt}}<p class="text-3xl text-title font-semibold">{{custom_excerpt}}</p>{{/if}}
     </header>
 


### PR DESCRIPTION
Currently the title font size is small, smaller than excerpt. Remove the redundant class to correct font size