### PR TITLE
components:datetime: replace featured story icon

### DIFF
--- a/partials/components/datetime.hbs
+++ b/partials/components/datetime.hbs
@@ -2,5 +2,9 @@
     <time class="datetime capitalize" datetime="{{date format="YYYY-MM-DD"}}" {{#if updated_at}}title="{{t "Updated"}} {{date updated_at format="D MMM YYYY"}}"{{/if}}>{{date format="D MMM YYYY"}}</time>
     <span class="bull mx-1">·</span>
     <span class="readingTime cursor-default" title="{{reading_time seconds=(t "< 1 min read") minute=(t "1 min read") minutes=(t "% min read")}}">{{reading_time seconds=(t "< 1 min read") minute=(t "1 min read") minutes=(t "% min read")}}</span>
-    {{#if featured}}<svg class="icon icon--star is-small p-1"><use xlink:href="#icon-star"></use></svg>{{/if}}
+    {{#if featured}}
+        <svg class="bull mx-1" width="16" height="17" viewBox="0 0 16 17" fill="none" color="var(--ghost-accent-color)" xmlns="http://www.w3.org/2000/svg">
+            <path d="M4.49365 4.58752C3.53115 6.03752 2.74365 7.70002 2.74365 9.25002C2.74365 10.6424 3.29678 11.9778 4.28134 12.9623C5.26591 13.9469 6.60127 14.5 7.99365 14.5C9.38604 14.5 10.7214 13.9469 11.706 12.9623C12.6905 11.9778 13.2437 10.6424 13.2437 9.25002C13.2437 6.00002 10.9937 3.50002 9.16865 1.68127L6.99365 6.25002L4.49365 4.58752Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
+        </svg>
+    {{/if}}
 </div>


### PR DESCRIPTION
Just a small improvement for featured story icon.
I get the svg icon from default official ghost theme which uses `var(--ghost-accent-color)` as color.