### PR TITLE
partials: remove redundant class

### DIFF
--- a/partials/article/article-header.hbs
+++ b/partials/article/article-header.hbs
@@ -7,7 +7,7 @@
 <h1 class="post-title text-32 md:text-4xl lg:text-44 text-title leading-tight">{{title}}</h1>
 {{#if custom_excerpt}}<p class="post-excerpt mt-6 text-22 text-gray-500">{{custom_excerpt}}</p>{{/if}}
 
-<div class="post-share flex flex-col md:flex-row mt-8">
+<div class="flex flex-col md:flex-row mt-8">
     {{!-- [Author, DateTime, Reading Time] - ./partials/components/author-meta.hbs --}}
     {{> "components/author-meta"}}
 

--- a/partials/components/social-share.hbs
+++ b/partials/components/social-share.hbs
@@ -1,4 +1,4 @@
-<aside class="post-shasre text-title flex items-center flex-none{{#unless class}} md:justify-end {{else}} {{class}}{{/unless}}">
+<aside class="text-title flex items-center flex-none{{#unless class}} md:justify-end {{else}} {{class}}{{/unless}}">
     <span class="share-label text-gray-500 text-sm mr-2">{{t "Share"}}:</span>
     {{!-- Share on Twitter --}}
     <a href="https://twitter.com/share?text={{encode title}}&amp;url={{url absolute="true"}}"


### PR DESCRIPTION
Class `post-share` is not used and also blocked by [Adguard Social Media filter](https://github.com/AdguardTeam/FiltersRegistry/blob/master/filters/filter_4_Social/filter.txt#L10571=).
This leads to the hidden author info.