### PR TITLE
remove flex-none class from header

### DIFF
--- a/partials/layout/header.hbs
+++ b/partials/layout/header.hbs
@@ -1,7 +1,7 @@
 <header class="header js-header h-16 w-full text-sm flex items-center sticky top-0 z-20">
     <div class="header-wrap mx-auto flex items-center flex-auto px-4 w-full max-w-extreme">
         {{!-- Logo --}}
-        <div class="header-left mr-5 flex flex-none items-center">
+        <div class="header-left mr-5 flex items-center">
             <a href="{{@site.url}}"
                 class="header-logo inline-block leading-none godo-tracking"
                 data-event-category="Header"


### PR DESCRIPTION
"flex: none" equals to
flex-grow: 0
flex-shrink: 0
flex-basis: auto

Why would you want to prevent shrinking in the header? This causes issue in mobiles or smaller screens. Just remove the class, omitting "flex" property equals to

flex-grow: 0
flex-shrink: 1
flex-basis: auto