### PR TITLE
Replaced 'Read more' with 'Read article'

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -42,7 +42,7 @@
   "Get the best viral stories straight into your inbox!": "Get the best viral stories straight into your inbox!",
   "Latest Posts": "Latest Posts",
   "No posts": "No posts",
-  "Read more": "Read more",
+  "Read more": "Read article",
   "See all % posts": "See all % posts",
   "Stay up to date! Get all the latest & greatest posts delivered straight to your inbox": "Stay up to date! Get all the latest & greatest posts delivered straight to your inbox",
   "youremail@example.com": "youremail@example.com",

--- a/partials/story/story-grid.hbs
+++ b/partials/story/story-grid.hbs
@@ -37,7 +37,7 @@
             {{else}}
 
             {{!-- Read more --}}
-            <a href="{{url}}" class="link is-hover font-medium">{{t "Read more"}}<svg class="icon is-medium"><use xlink:href="#icon-arrow"></use></svg></a>
+            <a href="{{url}}" class="link is-hover font-medium" aria-label="Read {{title}}">{{t "Read more"}}<svg class="icon is-medium"><use xlink:href="#icon-arrow"></use></svg></a>
             {{/match}}
         </div>
 
@@ -64,7 +64,7 @@
             {{else}}
 
             {{!-- Read more --}}
-            <a href="{{url}}" class="link is-hover font-medium">{{t "Read more"}}<svg class="icon is-medium"><use xlink:href="#icon-arrow"></use></svg></a>
+            <a href="{{url}}" class="link is-hover font-medium" aria-label="Read {{title}}">{{t "Read more"}}<svg class="icon is-medium"><use xlink:href="#icon-arrow"></use></svg></a>
             {{/match}}
         </div>
 

--- a/partials/story/story-post.hbs
+++ b/partials/story/story-post.hbs
@@ -28,7 +28,7 @@
 
     <div class="story-post-body">
         <div class="post-body text-xl mb-5"><p>{{excerpt}}</p></div>
-        <a href="{{url}}" class="link is-hover font-medium">
+        <a href="{{url}}" class="link is-hover font-medium" aria-label="Read {{title}}">
             {{t "Read more"}}
             <svg class="icon is-medium"><use xlink:href="#icon-arrow"></use></svg>
         </a>


### PR DESCRIPTION
As discussed on #178, only 'en' translation has been updated to change link text from 'Read more' to 'Read article' and additionally, aria-label has been added on the links for accessibility.