### PR TITLE
Remove disruptive regex for URL validation

### DIFF
--- a/src/js/util/url-regular-expression.js
+++ b/src/js/util/url-regular-expression.js
@@ -1,1 +1,7 @@
-export default url => /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \+\.-]*)*\/?$/.test(url) //eslint-disable-line
+export default (url) => {
+  try {
+    return Boolean(new URL(url));
+  } catch (e) {
+    return false;
+  }
+};


### PR DESCRIPTION
The provided changes remove a very destructive regex.

I will provide the lighthouse reports for the before and after

<img width="926" height="842" alt="image" src="https://github.com/user-attachments/assets/bb6eddba-0f64-455b-926f-3206231980e1" />
<img width="926" height="842" alt="image" src="https://github.com/user-attachments/assets/e4b15f3e-aa64-44f9-9af6-b8c1200393f9" />

<img width="933" height="227" alt="Untitled" src="https://github.com/user-attachments/assets/4d617ec6-32d0-4176-9717-ab1fe70a442f" />

It would seem that this causes a recursion when checking for the validity of social media links. I'm unsure of when this happens exactly (on a blank site nothing happens) but on my full site it does slow the page down by 14 seconds.